### PR TITLE
UI Tweaks

### DIFF
--- a/assets/mLRS_metadata.py
+++ b/assets/mLRS_metadata.py
@@ -73,9 +73,9 @@ g_targetDict = {
                 'Flash method: connect to USB (select COM port)\n\n' +
                 'Wireless bridge: ESP8285\n' +
                 'Dip switches need to be set as follow:\n' +
-                '  1,2 on:    update firmware on main ESP32, USB is connected to UARTO\n' +
-                '  3,4 on:    normal operation mode, USB is not used, UARTO connected to ESP8285\n' +
-                '  5,6,7 on:  update firmware on ESP8285, USB is connected to ESP8285 UART\n',
+                '  1,2 on:    update firmware on main ESP32, USB connected to UARTO\n' +
+                '  3,4 on:    normal operation mode, USB not used, UARTO connected to ESP8285\n' +
+                '  5,6,7 on:  update firmware on ESP8285, USB connected to ESP8285 UART\n',
             'wireless' : {
                 'chipset' : 'esp8266', 
                 'reset' : 'dtr', 

--- a/assets/mLRS_metadata.py
+++ b/assets/mLRS_metadata.py
@@ -89,8 +89,8 @@ g_targetDict = {
                 'Flash method: connect to USB (select COM port)\n\n' +
                 'Wireless bridge: ESP8285\n' +
                 'For flashing the wireless bridge: \n' +
-                '  - set SerDest to serial2\n' +
-                '  - set SerBaudrate to 115200\n' +
+                '  - set Tx SerDest to serial2\n' +
+                '  - set Tx SerBaudrate to 115200\n' +
                 '  - put Tx module into FLASH_ESP mode via OLED Actions page\n',
             'wireless' : {
                 'chipset' : 'esp8266',

--- a/assets/mLRS_metadata.py
+++ b/assets/mLRS_metadata.py
@@ -56,7 +56,7 @@ g_targetDict = {
     'tx-matek' : {
         'flashmethod' : 'dfu',
         'description' : 
-            'Flash method: DFU, connect to USB\n' +
+            'Flash method: DFU, connect to USB\n\n' +
             'Wireless bridge: HC04, cannot be flashed\n',
     },
     'tx-E77-MBLKit' : {},
@@ -70,7 +70,7 @@ g_targetDict = {
     'tx-betafpv' : {
         'tx-betafpv-micro-1w-2400' : {
             'description' : 
-                'Flash method: connect to USB (select COM port)\n' +
+                'Flash method: connect to USB (select COM port)\n\n' +
                 'Wireless bridge: ESP8285\n' +
                 'Dip switches need to be set as follow:\n' +
                 '  1,2 on:    update firmware on main ESP32, USB is connected to UARTO\n' +
@@ -86,7 +86,7 @@ g_targetDict = {
     'tx-radiomaster' : {
         'tx-radiomaster-bandit' : {
             'description' : 
-                'Flash method: connect to USB (select COM port)\n' +
+                'Flash method: connect to USB (select COM port)\n\n' +
                 'Wireless bridge: ESP8285\n' +
                 'For flashing the wireless bridge: \n' +
                 '  - set SerDest to serial2\n' +
@@ -108,7 +108,7 @@ g_targetDict = {
         'description' : 
             "Supported radios: T20 V2, T15, T14, T-Pro S\n" +
             "Flash method: radio passthrough\n" + 
-            "  - connect to USB of your radio and select 'USB Serial (VCP)'\n" +
+            "  - connect to USB of your radio and select 'USB Serial (VCP)'\n\n" +
             "Wireless bridge: ESP8285\n" +
             "For flashing the wireless bridge:\n" +
             "  - connect to USB of your radio and select 'USB Serial (VCP)'\n",
@@ -117,7 +117,7 @@ g_targetDict = {
         'description' : 
             "Supported radios: TX16S, TX12, MT12, Zorro, Pocket, Boxer\n" +
             "Flash method: radio passthrough\n" + 
-            "  - connect to USB of your radio and select 'USB Serial (VCP)'\n" +
+            "  - connect to USB of your radio and select 'USB Serial (VCP)'\n\n" +
             "Wireless bridge: ESP8285\n" +
             "For flashing the wireless bridge:\n" +
             "  - connect to USB of your radio and select 'USB Serial (VCP)'\n",

--- a/mLRS_Flasher.py
+++ b/mLRS_Flasher.py
@@ -932,7 +932,7 @@ class App(ctk.CTk):
         super().__init__()
 
         self.title('mLRS Flasher Desktop App '+app_version)
-        self.geometry('700x500')
+        self.geometry('800x600')
         #self.iconbitmap(os.path.join('assets','mLRS_logo_round.ico')) # does not work on Mac
         self.wm_iconbitmap()
         self.iconphoto(False, ImageTk.PhotoImage(file = os.path.join('assets','mLRS_logo_round.ico')))
@@ -1185,7 +1185,7 @@ class App(ctk.CTk):
         self.fTxModuleExternal_DeviceType_label.grid(row=wrow, column=0, padx=20, pady=20)
         self.fTxModuleExternal_DeviceType_menu = ctk.CTkOptionMenu(self.fTxModuleExternal,
             values=["downloading..."],
-            width=300, # this sets a min width, can grow larger
+            width=400, # this sets a min width, can grow larger
             #dynamic_resizing = False, # when false it prevents the box to grow with the entry
             command=self.fTxModuleExternal_DeviceType_menu_event)
         self.fTxModuleExternal_DeviceType_menu.grid(row=wrow, column=1, padx=(0,20), sticky="w")
@@ -1198,7 +1198,7 @@ class App(ctk.CTk):
         self.fTxModuleExternal_FirmwareVersion_label.grid(row=wrow, column=0, padx=20, pady=20)
         self.fTxModuleExternal_FirmwareVersion_menu = ctk.CTkOptionMenu(self.fTxModuleExternal,
             values=["downloading..."],
-            width=300,
+            width=400,
             command=self.fTxModuleExternal_FirmwareVersion_menu_event)
         self.fTxModuleExternal_FirmwareVersion_menu.grid(row=wrow, column=1, padx=(0,20), sticky="w")
         wrow += 1
@@ -1210,7 +1210,7 @@ class App(ctk.CTk):
         self.fTxModuleExternal_FirmwareFile_label.grid(row=wrow, column=0, padx=20, pady=20)
         self.fTxModuleExternal_FirmwareFile_menu = ctk.CTkOptionMenu(self.fTxModuleExternal,
             values=["downloading..."],
-            width=300,
+            width=400,
             command=self.fTxModuleExternal_FirmwareFile_menu_event)
         self.fTxModuleExternal_FirmwareFile_menu.grid(row=wrow, column=1, padx=(0,20), sticky="w")
         wrow += 1
@@ -1330,7 +1330,7 @@ class App(ctk.CTk):
         self.fReceiver_DeviceType_label.grid(row=wrow, column=0, padx=20, pady=20)
         self.fReceiver_DeviceType_menu = ctk.CTkOptionMenu(self.fReceiver,
             values=["downloading..."],
-            width=300,
+            width=400,
             command=self.fReceiver_DeviceType_menu_event)
         self.fReceiver_DeviceType_menu.grid(row=wrow, column=1, padx=(0,20), sticky="w")
         wrow += 1
@@ -1342,7 +1342,7 @@ class App(ctk.CTk):
         self.fReceiver_FirmwareVersion_label.grid(row=wrow, column=0, padx=20, pady=20)
         self.fReceiver_FirmwareVersion_menu = ctk.CTkOptionMenu(self.fReceiver,
             values=["downloading..."],
-            width=300,
+            width=400,
             command=self.fReceiver_FirmwareVersion_menu_event)
         self.fReceiver_FirmwareVersion_menu.grid(row=wrow, column=1, padx=(0,20), sticky="w")
         wrow += 1
@@ -1354,7 +1354,7 @@ class App(ctk.CTk):
         self.fReceiver_FirmwareFile_label.grid(row=wrow, column=0, padx=20, pady=20)
         self.fReceiver_FirmwareFile_menu = ctk.CTkOptionMenu(self.fReceiver,
             values=["downloading..."],
-            width=300,
+            width=400,
             command=self.fReceiver_FirmwareFile_menu_event)
         self.fReceiver_FirmwareFile_menu.grid(row=wrow, column=1, padx=(0,20), sticky="w")
         wrow += 1
@@ -1396,7 +1396,7 @@ class App(ctk.CTk):
         self.fTxModuleInternal_DeviceType_label.grid(row=wrow, column=0, padx=20, pady=20)
         self.fTxModuleInternal_DeviceType_menu = ctk.CTkOptionMenu(self.fTxModuleInternal,
             values=["downloading..."],
-            width=300,
+            width=400,
             command=self.fTxModuleInternal_DeviceType_menu_event)
         self.fTxModuleInternal_DeviceType_menu.grid(row=wrow, column=1, padx=(0,20), sticky="w")
         wrow += 1
@@ -1408,7 +1408,7 @@ class App(ctk.CTk):
         self.fTxModuleInternal_FirmwareVersion_label.grid(row=wrow, column=0, padx=20, pady=20)
         self.fTxModuleInternal_FirmwareVersion_menu = ctk.CTkOptionMenu(self.fTxModuleInternal,
             values=["downloading..."],
-            width=300,
+            width=400,
             command=self.fTxModuleInternal_FirmwareVersion_menu_event)
         self.fTxModuleInternal_FirmwareVersion_menu.grid(row=wrow, column=1, padx=(0,20), sticky="w")
         wrow += 1
@@ -1420,7 +1420,7 @@ class App(ctk.CTk):
         self.fTxModuleInternal_FirmwareFile_label.grid(row=wrow, column=0, padx=20, pady=20)
         self.fTxModuleInternal_FirmwareFile_menu = ctk.CTkOptionMenu(self.fTxModuleInternal,
             values=["downloading..."],
-            width=300,
+            width=400,
             command=self.fTxModuleInternal_FirmwareFile_menu_event)
         self.fTxModuleInternal_FirmwareFile_menu.grid(row=wrow, column=1, padx=(0,20), sticky="w")
         wrow += 1
@@ -1509,7 +1509,7 @@ class App(ctk.CTk):
         self.fLuaScript_FirmwareVersion_label.grid(row=wrow, column=0, padx=20, pady=20)
         self.fLuaScript_FirmwareVersion_menu = ctk.CTkOptionMenu(self.fLuaScript,
             values=["downloading..."],
-            width=300,
+            width=400,
             command=self.fLuaScript_FirmwareVersion_menu_event)
         self.fLuaScript_FirmwareVersion_menu.grid(row=wrow, column=1, padx=(0,20), sticky="w")
         wrow += 1
@@ -1521,7 +1521,7 @@ class App(ctk.CTk):
         self.fLuaScript_RadioScreen_label.grid(row=wrow, column=0, padx=20, pady=20)
         self.fLuaScript_RadioScreen_menu = ctk.CTkOptionMenu(self.fLuaScript,
             values=["downloading..."],
-            width=300,
+            width=400,
             command=self.fLuaScript_RadioScreen_menu_event)
         self.fLuaScript_RadioScreen_menu.grid(row=wrow, column=1, padx=(0,20), sticky="w")
         wrow += 1

--- a/mLRS_Flasher.py
+++ b/mLRS_Flasher.py
@@ -1222,7 +1222,8 @@ class App(ctk.CTk):
 
         self.fTxModuleExternal_Flash_button = ctk.CTkButton(self.fTxModuleExternal_fFlash,
             text = "Flash Tx Module",
-            command = self.fTxModuleExternal_Flash_button_event)
+            command = self.fTxModuleExternal_Flash_button_event,
+            fg_color="green")
         self.fTxModuleExternal_Flash_button.grid(row=0, column=0)
 
         self.fTxModuleExternal_ComPort_menu = CTkCompPortOptionMenu(self.fTxModuleExternal_fFlash,
@@ -1247,7 +1248,8 @@ class App(ctk.CTk):
 
         self.fTxModuleExternal_WirelessBridgeFlash_button = ctk.CTkButton(self.fTxModuleExternal_fWirelessBridge,
             text = "Flash Wireless Bridge",
-            command = self.fTxModuleExternal_WirelessBridgeFlash_button_event)
+            command = self.fTxModuleExternal_WirelessBridgeFlash_button_event,
+            fg_color="green")
         self.fTxModuleExternal_WirelessBridgeFlash_button.grid(row=1, column=0, pady=(20,0))
 
         #-- Description text box --
@@ -1362,7 +1364,8 @@ class App(ctk.CTk):
         # Flash Button
         self.fReceiver_Flash_button = ctk.CTkButton(self.fReceiver,
             text = "Flash Receiver",
-            command = self.fReceiver_Flash_button_event)
+            command = self.fReceiver_Flash_button_event,
+            fg_color="green")
         self.fReceiver_Flash_button.grid(row=wrow, column=0, columnspan=2, padx=20, pady=20)
 
     def fReceiver_DeviceType_menu_event(self, opt):
@@ -1428,7 +1431,8 @@ class App(ctk.CTk):
         # Flash Button
         self.fTxModuleInternal_Flash_button = ctk.CTkButton(self.fTxModuleInternal,
             text = "Flash Tx Module",
-            command = self.fTxModuleInternal_Flash_button_event)
+            command = self.fTxModuleInternal_Flash_button_event,
+            fg_color="green")
         self.fTxModuleInternal_Flash_button.grid(row=wrow, column=0, columnspan=2, padx=20, pady=20)
         wrow += 1
 
@@ -1446,7 +1450,8 @@ class App(ctk.CTk):
 
         self.fTxModuleInternal_WirelessBridgeFlash_button = ctk.CTkButton(self.fTxModuleInternal_fWirelessBridge,
             text = "Flash Wireless Bridge",
-            command = self.fTxModuleInternal_WirelessBridgeFlash_button_event)
+            command = self.fTxModuleInternal_WirelessBridgeFlash_button_event,
+            fg_color="green")
         self.fTxModuleInternal_WirelessBridgeFlash_button.grid(row=1, column=0, pady=(20,0))
 
         #-- Description text box --
@@ -1529,7 +1534,8 @@ class App(ctk.CTk):
         # Download Color Script Button
         self.fLuaScript_Download_button = ctk.CTkButton(self.fLuaScript,
             text = "Download Lua Script",
-            command = self.fLuaScript_Download_button_event)
+            command = self.fLuaScript_Download_button_event,
+            fg_color="green")
         self.fLuaScript_Download_button.grid(row=wrow, column=0, columnspan=2, padx=20, pady=20)
         wrow += 1
 

--- a/mLRS_Flasher.py
+++ b/mLRS_Flasher.py
@@ -1185,7 +1185,7 @@ class App(ctk.CTk):
         self.fTxModuleExternal_DeviceType_label.grid(row=wrow, column=0, padx=20, pady=20)
         self.fTxModuleExternal_DeviceType_menu = ctk.CTkOptionMenu(self.fTxModuleExternal,
             values=["downloading..."],
-            width=400, # this sets a min width, can grow larger
+            width=440, # this sets a min width, can grow larger
             #dynamic_resizing = False, # when false it prevents the box to grow with the entry
             command=self.fTxModuleExternal_DeviceType_menu_event)
         self.fTxModuleExternal_DeviceType_menu.grid(row=wrow, column=1, padx=(0,20), sticky="w")
@@ -1198,7 +1198,7 @@ class App(ctk.CTk):
         self.fTxModuleExternal_FirmwareVersion_label.grid(row=wrow, column=0, padx=20, pady=20)
         self.fTxModuleExternal_FirmwareVersion_menu = ctk.CTkOptionMenu(self.fTxModuleExternal,
             values=["downloading..."],
-            width=400,
+            width=440,
             command=self.fTxModuleExternal_FirmwareVersion_menu_event)
         self.fTxModuleExternal_FirmwareVersion_menu.grid(row=wrow, column=1, padx=(0,20), sticky="w")
         wrow += 1
@@ -1210,7 +1210,7 @@ class App(ctk.CTk):
         self.fTxModuleExternal_FirmwareFile_label.grid(row=wrow, column=0, padx=20, pady=20)
         self.fTxModuleExternal_FirmwareFile_menu = ctk.CTkOptionMenu(self.fTxModuleExternal,
             values=["downloading..."],
-            width=400,
+            width=440,
             command=self.fTxModuleExternal_FirmwareFile_menu_event)
         self.fTxModuleExternal_FirmwareFile_menu.grid(row=wrow, column=1, padx=(0,20), sticky="w")
         wrow += 1
@@ -1330,7 +1330,7 @@ class App(ctk.CTk):
         self.fReceiver_DeviceType_label.grid(row=wrow, column=0, padx=20, pady=20)
         self.fReceiver_DeviceType_menu = ctk.CTkOptionMenu(self.fReceiver,
             values=["downloading..."],
-            width=400,
+            width=440,
             command=self.fReceiver_DeviceType_menu_event)
         self.fReceiver_DeviceType_menu.grid(row=wrow, column=1, padx=(0,20), sticky="w")
         wrow += 1
@@ -1342,7 +1342,7 @@ class App(ctk.CTk):
         self.fReceiver_FirmwareVersion_label.grid(row=wrow, column=0, padx=20, pady=20)
         self.fReceiver_FirmwareVersion_menu = ctk.CTkOptionMenu(self.fReceiver,
             values=["downloading..."],
-            width=400,
+            width=440,
             command=self.fReceiver_FirmwareVersion_menu_event)
         self.fReceiver_FirmwareVersion_menu.grid(row=wrow, column=1, padx=(0,20), sticky="w")
         wrow += 1
@@ -1354,7 +1354,7 @@ class App(ctk.CTk):
         self.fReceiver_FirmwareFile_label.grid(row=wrow, column=0, padx=20, pady=20)
         self.fReceiver_FirmwareFile_menu = ctk.CTkOptionMenu(self.fReceiver,
             values=["downloading..."],
-            width=400,
+            width=440,
             command=self.fReceiver_FirmwareFile_menu_event)
         self.fReceiver_FirmwareFile_menu.grid(row=wrow, column=1, padx=(0,20), sticky="w")
         wrow += 1
@@ -1396,7 +1396,7 @@ class App(ctk.CTk):
         self.fTxModuleInternal_DeviceType_label.grid(row=wrow, column=0, padx=20, pady=20)
         self.fTxModuleInternal_DeviceType_menu = ctk.CTkOptionMenu(self.fTxModuleInternal,
             values=["downloading..."],
-            width=400,
+            width=440,
             command=self.fTxModuleInternal_DeviceType_menu_event)
         self.fTxModuleInternal_DeviceType_menu.grid(row=wrow, column=1, padx=(0,20), sticky="w")
         wrow += 1
@@ -1408,7 +1408,7 @@ class App(ctk.CTk):
         self.fTxModuleInternal_FirmwareVersion_label.grid(row=wrow, column=0, padx=20, pady=20)
         self.fTxModuleInternal_FirmwareVersion_menu = ctk.CTkOptionMenu(self.fTxModuleInternal,
             values=["downloading..."],
-            width=400,
+            width=440,
             command=self.fTxModuleInternal_FirmwareVersion_menu_event)
         self.fTxModuleInternal_FirmwareVersion_menu.grid(row=wrow, column=1, padx=(0,20), sticky="w")
         wrow += 1
@@ -1420,7 +1420,7 @@ class App(ctk.CTk):
         self.fTxModuleInternal_FirmwareFile_label.grid(row=wrow, column=0, padx=20, pady=20)
         self.fTxModuleInternal_FirmwareFile_menu = ctk.CTkOptionMenu(self.fTxModuleInternal,
             values=["downloading..."],
-            width=400,
+            width=440,
             command=self.fTxModuleInternal_FirmwareFile_menu_event)
         self.fTxModuleInternal_FirmwareFile_menu.grid(row=wrow, column=1, padx=(0,20), sticky="w")
         wrow += 1
@@ -1509,7 +1509,7 @@ class App(ctk.CTk):
         self.fLuaScript_FirmwareVersion_label.grid(row=wrow, column=0, padx=20, pady=20)
         self.fLuaScript_FirmwareVersion_menu = ctk.CTkOptionMenu(self.fLuaScript,
             values=["downloading..."],
-            width=400,
+            width=440,
             command=self.fLuaScript_FirmwareVersion_menu_event)
         self.fLuaScript_FirmwareVersion_menu.grid(row=wrow, column=1, padx=(0,20), sticky="w")
         wrow += 1
@@ -1521,7 +1521,7 @@ class App(ctk.CTk):
         self.fLuaScript_RadioScreen_label.grid(row=wrow, column=0, padx=20, pady=20)
         self.fLuaScript_RadioScreen_menu = ctk.CTkOptionMenu(self.fLuaScript,
             values=["downloading..."],
-            width=400,
+            width=440,
             command=self.fLuaScript_RadioScreen_menu_event)
         self.fLuaScript_RadioScreen_menu.grid(row=wrow, column=1, padx=(0,20), sticky="w")
         wrow += 1

--- a/mLRS_Flasher.py
+++ b/mLRS_Flasher.py
@@ -1223,7 +1223,7 @@ class App(ctk.CTk):
         self.fTxModuleExternal_Flash_button = ctk.CTkButton(self.fTxModuleExternal_fFlash,
             text = "Flash Tx Module",
             command = self.fTxModuleExternal_Flash_button_event,
-            fg_color="green")
+            fg_color="green", hover_color="#006400")
         self.fTxModuleExternal_Flash_button.grid(row=0, column=0)
 
         self.fTxModuleExternal_ComPort_menu = CTkCompPortOptionMenu(self.fTxModuleExternal_fFlash,
@@ -1249,7 +1249,7 @@ class App(ctk.CTk):
         self.fTxModuleExternal_WirelessBridgeFlash_button = ctk.CTkButton(self.fTxModuleExternal_fWirelessBridge,
             text = "Flash Wireless Bridge",
             command = self.fTxModuleExternal_WirelessBridgeFlash_button_event,
-            fg_color="green")
+            fg_color="green", hover_color="#006400")
         self.fTxModuleExternal_WirelessBridgeFlash_button.grid(row=1, column=0, pady=(20,0))
 
         #-- Description text box --
@@ -1365,7 +1365,7 @@ class App(ctk.CTk):
         self.fReceiver_Flash_button = ctk.CTkButton(self.fReceiver,
             text = "Flash Receiver",
             command = self.fReceiver_Flash_button_event,
-            fg_color="green")
+            fg_color="green", hover_color="#006400")
         self.fReceiver_Flash_button.grid(row=wrow, column=0, columnspan=2, padx=20, pady=20)
 
     def fReceiver_DeviceType_menu_event(self, opt):
@@ -1432,7 +1432,7 @@ class App(ctk.CTk):
         self.fTxModuleInternal_Flash_button = ctk.CTkButton(self.fTxModuleInternal,
             text = "Flash Tx Module",
             command = self.fTxModuleInternal_Flash_button_event,
-            fg_color="green")
+            fg_color="green", hover_color="#006400")
         self.fTxModuleInternal_Flash_button.grid(row=wrow, column=0, columnspan=2, padx=20, pady=20)
         wrow += 1
 
@@ -1451,7 +1451,7 @@ class App(ctk.CTk):
         self.fTxModuleInternal_WirelessBridgeFlash_button = ctk.CTkButton(self.fTxModuleInternal_fWirelessBridge,
             text = "Flash Wireless Bridge",
             command = self.fTxModuleInternal_WirelessBridgeFlash_button_event,
-            fg_color="green")
+            fg_color="green", hover_color="#006400")
         self.fTxModuleInternal_WirelessBridgeFlash_button.grid(row=1, column=0, pady=(20,0))
 
         #-- Description text box --
@@ -1535,7 +1535,7 @@ class App(ctk.CTk):
         self.fLuaScript_Download_button = ctk.CTkButton(self.fLuaScript,
             text = "Download Lua Script",
             command = self.fLuaScript_Download_button_event,
-            fg_color="green")
+            fg_color="green", hover_color="#006400")
         self.fLuaScript_Download_button.grid(row=wrow, column=0, columnspan=2, padx=20, pady=20)
         wrow += 1
 


### PR DESCRIPTION
- Makes the window a little bigger, so one doesn't have to expand the bottom window
- Expands field width so that all fields align (440 width looked plenty to me, longest string was RP4TD Dev)
- Puts another new line between the Flash method and Wireless bridge to make it easier to read
- Makes download / flash buttons green (chosen as Github uses green buttons)

Before:
![image](https://github.com/user-attachments/assets/a21c9fa0-1eb9-423d-9867-d194626b1a4e)

After:
![image](https://github.com/user-attachments/assets/04acaa67-068b-4f2f-b11c-86ee9b43f244)
