### PR TITLE
Radiomaster Pocket identifies as EdgeTX instead of OpenTX

### DIFF
--- a/edgetxInitPassthru.py
+++ b/edgetxInitPassthru.py
@@ -28,9 +28,12 @@ def find_radio_serial_ports():
         return None
     radioportList = []
     for port in portList:
+        print('*',port.device, port.name, port.description)
+        print(' ',port.hwid, port.vid, port.pid)
+        print(' ',port.manufacturer, port.location, port.product, port.interface)
         if port.vid == 0x0483 and port.pid == 0x5740:
             if os.name == 'posix': # we do have more info on this os
-                if port.manufacturer == 'OpenTX':
+                if port.manufacturer == 'OpenTX' or port.manufacturer == 'EdgeTX':
                     radioportList.append(port.device)
             else:
                 radioportList.append(port.device)


### PR DESCRIPTION
I'm not sure if this was a RM local change or if EdgeTX changed this at some point.  I still use the original RM EdgeTX firmware on the pocket.