### PR TITLE
Internal ESP Fixes

### DIFF
--- a/edgetxInitPassthru.py
+++ b/edgetxInitPassthru.py
@@ -116,7 +116,7 @@ def open_passthrough(comport = None, baudrate = 115200, wirelessbridge = None):
             do_error('Sorry, something went wrong.')
 
     if not wirelessbridge:
-        res = execute_cli_command(ser, b'set rfmod 0 bootpin 1', expected = b'bootpin set')
+        res = execute_cli_command(ser, b'set rfmod 0 bootpin 1', expected = b'bootcmd set')
         if not res:
             do_error('Sorry, something went wrong.')
         time.sleep(.1)
@@ -130,11 +130,11 @@ def open_passthrough(comport = None, baudrate = 115200, wirelessbridge = None):
         do_error('Sorry, something went wrong.')
     time.sleep(1)
 
-    res = execute_cli_command(ser, b'set rfmod 0 bootpin 1', expected = b'bootpin set')
+    res = execute_cli_command(ser, b'set rfmod 0 bootpin 1', expected = b'bootcmd set')
     if not res:
         do_error('Sorry, something went wrong.')
     time.sleep(1)
-    res = execute_cli_command(ser, b'set rfmod 0 bootpin 0', expected = b'bootpin reset')
+    res = execute_cli_command(ser, b'set rfmod 0 bootpin 0', expected = b'bootcmd reset')
     if not res:
         do_error('Sorry, something went wrong.')
 

--- a/edgetxInitPassthru.py
+++ b/edgetxInitPassthru.py
@@ -116,7 +116,7 @@ def open_passthrough(comport = None, baudrate = 115200, wirelessbridge = None):
             do_error('Sorry, something went wrong.')
 
     if not wirelessbridge:
-        res = execute_cli_command(ser, b'set rfmod 0 bootpin 1', expected = b'bootcmd set')
+        res = execute_cli_command(ser, b'set rfmod 0 bootpin 1', expected = b'boot')
         if not res:
             do_error('Sorry, something went wrong.')
         time.sleep(.1)
@@ -130,11 +130,11 @@ def open_passthrough(comport = None, baudrate = 115200, wirelessbridge = None):
         do_error('Sorry, something went wrong.')
     time.sleep(1)
 
-    res = execute_cli_command(ser, b'set rfmod 0 bootpin 1', expected = b'bootcmd set')
+    res = execute_cli_command(ser, b'set rfmod 0 bootpin 1', expected = b'boot')
     if not res:
         do_error('Sorry, something went wrong.')
     time.sleep(1)
-    res = execute_cli_command(ser, b'set rfmod 0 bootpin 0', expected = b'bootcmd reset')
+    res = execute_cli_command(ser, b'set rfmod 0 bootpin 0', expected = b'boot')
     if not res:
         do_error('Sorry, something went wrong.')
 

--- a/edgetxInitPassthru.py
+++ b/edgetxInitPassthru.py
@@ -115,6 +115,7 @@ def open_passthrough(comport = None, baudrate = 115200, wirelessbridge = None):
         if not res:
             do_error('Sorry, something went wrong.')
 
+    # EdgeTx version <= 2.10 responds with 'bootpin set', on >= 2.11 the response is 'bootcmd set' 
     if not wirelessbridge:
         res = execute_cli_command(ser, b'set rfmod 0 bootpin 1', expected = b'boot')
         if not res:

--- a/mLRS_Flasher.py
+++ b/mLRS_Flasher.py
@@ -433,7 +433,7 @@ def flashInternalElrsTxModule(programmer, firmware):
     #print(filename)
     #print(programmer)
     baudrate = 921600
-    radioport = radio.open_passthrough(None, baudrate, wirelessbridge = False)
+    radioport = radio.open_passthrough(comport = None, baudrate = baudrate, wirelessbridge = False)
 
     print()
     print('*** 3. Flashing the internal Tx Module ***')
@@ -459,7 +459,7 @@ def flashInternalElrsTxModuleWirelessBridge(programmer, firmware):
 
     #print(programmer)
     baudrate = 115200
-    radioport = radio.open_passthrough(None, baudrate, wirelessbridge = True)
+    radioport = radio.open_passthrough(comport = None, baudrate = baudrate, wirelessbridge = True)
 
     print()
     print('*** 3. Flashing the wireless bridge of the internal Tx Module ***')

--- a/mLRS_Flasher.py
+++ b/mLRS_Flasher.py
@@ -433,7 +433,7 @@ def flashInternalElrsTxModule(programmer, firmware):
     #print(filename)
     #print(programmer)
     baudrate = 921600
-    radioport = radio.open_passthrough(baudrate)
+    radioport = radio.open_passthrough(None, baudrate, wirelessbridge = False)
 
     print()
     print('*** 3. Flashing the internal Tx Module ***')
@@ -459,7 +459,7 @@ def flashInternalElrsTxModuleWirelessBridge(programmer, firmware):
 
     #print(programmer)
     baudrate = 115200
-    radioport = radio.open_passthrough(baudrate, wirelessbridge = True)
+    radioport = radio.open_passthrough(None, baudrate, wirelessbridge = True)
 
     print()
     print('*** 3. Flashing the wireless bridge of the internal Tx Module ***')


### PR DESCRIPTION
- Updates the radio.open_passthrough function calls to have all the necessary arguments
- At least on EdgeTx 2.11, the response is now 'bootcmd' and not 'bootpin' so have made this more generic.

Tested on MacOS with Jumper Internal 2400, flashes both internal and bridge firmware successfully.

Edit - Also tested the .py on Windows without issues, not sure how to generate the Win App.