### PR TITLE
Delay for wireless bridge configuration

### DIFF
--- a/edgetxInitPassthru.py
+++ b/edgetxInitPassthru.py
@@ -132,6 +132,10 @@ def open_passthrough(comport = None, baudrate = 115200, wirelessbridge = None):
         do_error('Sorry, something went wrong.')
     time.sleep(1)
 
+    if wirelessbridge:
+        print('Waiting for bridge configuration to complete')
+        time.sleep(10)
+        
     res = execute_cli_command(ser, b'set rfmod 0 bootpin 1', expected = b'boot')
     if not res:
         do_error('Sorry, something went wrong.')


### PR DESCRIPTION
When flashing a wireless bridge via EdgeTx/mLRS passthrough, we need to wait for mLRS to configure the bridge before we ask mLRS to put it in download mode.

Enabling DEVICE_HAS_ESP_WIFI_BRIDGE_CONFIGURE is what was causing the problem I saw with flashing the wireless bridge.

10 seconds seems to be enough, though, if someone knows the maximum time configuration can take, we could use that info.

Tested on Jumper internal 900 with my 3 recent mLRS PRs.