### PR TITLE
Mac, Activate venv, gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ win_dist/*
 tools/win_build/*
 tools/win_dist/*
 tools/venv/*
+.DS_Store
 
 # Prerequisites
 *.d

--- a/run_mLRS_Flasher_mac.sh
+++ b/run_mLRS_Flasher_mac.sh
@@ -91,7 +91,8 @@ setup_virtualenv() {
 # Run the Python script inside the venv
 run_flasher() {
     status "🚀 Running mLRS_Flasher.py."
-    ./venv/bin/python mLRS_Flasher.py
+    source ./venv/bin/activate
+    python mLRS_Flasher.py
 }
 
 ### MAIN ###

--- a/run_mLRS_Flasher_mac.sh
+++ b/run_mLRS_Flasher_mac.sh
@@ -92,7 +92,7 @@ setup_virtualenv() {
 run_flasher() {
     status "🚀 Running mLRS_Flasher.py."
     source ./venv/bin/activate
-    python mLRS_Flasher.py
+    ./mLRS_Flasher.py
 }
 
 ### MAIN ###


### PR DESCRIPTION
- Nicer to activate the venv than call the binary.
- Ignore DS_Store files